### PR TITLE
Bugfix to work with Composer 1.x & 2.x

### DIFF
--- a/zray/zray.php
+++ b/zray/zray.php
@@ -38,6 +38,14 @@ class Composer
 
         $json = file_get_contents($jsonFile);
         $data = json_decode($json);
+	
+	/*
+	 * Composer 1.x - output is already an array
+	 * Composer 2.x - output is an object; the array we want is in the 'packages' property
+	 */
+	if (is_object($data) && isset($data->packages)) {
+            $data = $data->packages;
+	}
 
         foreach ($data as $package) {
             $source = (isset($package->source) && isset($package->source->url))


### PR DESCRIPTION
Composer 2.x output is an object with a 'packages' array. Composer 1.x simply output an array of packages.