### PR TITLE
Added safety check on 'package' object

### DIFF
--- a/zray/zray.php
+++ b/zray/zray.php
@@ -48,6 +48,7 @@ class Composer
 	}
 
         foreach ($data as $package) {
+	    if (!is_object($package)) continue;
             $source = (isset($package->source) && isset($package->source->url))
                 ? $package->source->url
                 : '';


### PR DESCRIPTION
The safety test added on line 51 avoids the generations of warnings related to the variable usage in the subsequent lines in case the variable is not an object (which happens fo example with Magento)